### PR TITLE
Add support for dat:// using domains

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -217,7 +217,7 @@ apkFullPath$.subscribe({
       global_apps[url] = {
         key: url,
         peers: 0,
-        readme: apkFullPath,
+        apkFullPath: apkFullPath,
       };
     }
   },

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -153,7 +153,6 @@ const readme$ = metadata$.mergeMap(({ json, dat, url }) => {
   return json.readme
     ? readFileInDat(dat, json.readme, "utf-8").map(contents => ({
         contents,
-        dat,
         url
       }))
     : Rx.Observable.empty();
@@ -187,13 +186,12 @@ metadata$.subscribe({
 
 // Update global_apps readme for an app
 readme$.subscribe({
-  next: ({ contents, dat }) => {
-    const datHash = (dat.key as Buffer).toString("hex");
-    if (global_apps[datHash]) {
-      global_apps[datHash].readme = contents;
+  next: ({ contents, url }) => {
+    if (global_apps[url]) {
+      global_apps[url].readme = contents;
     } else {
-      global_apps[datHash] = {
-        key: datHash,
+      global_apps[url] = {
+        key: url,
         peers: 0,
         readme: contents,
       };

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -50,7 +50,7 @@ export function joinNetwork(dat: any): Observable<any> {
 }
 
 export function looksLikeDatHash(str: string): boolean {
-  return str.length === 64;
+  return str !== 'icons';
 }
 
 export function trimProtocolPrefix(str: string): string {

--- a/src/frontend/screens/addition/index.ts
+++ b/src/frontend/screens/addition/index.ts
@@ -54,7 +54,7 @@ export default function addition(sources: Sources): Sinks {
 
   const addDat$ = actions.submit$
     .compose(sampleCombine(state$))
-    .filter(([_, state]) => state.textInput.length >= 64)
+    .filter(([_, state]) => state.textInput.startsWith('dat://'))
     .map(([_, state]) => state.textInput);
 
   const request$ = addDat$.map(datHash => ({

--- a/src/frontend/screens/addition/view.ts
+++ b/src/frontend/screens/addition/view.ts
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 export default function view(state$: Stream<State>): Stream<ScreenVNode> {
   return state$.map(state => {
-    const looksValid = state.textInput.length >= 64;
+    const looksValid = state.textInput.startsWith('dat://');
     const buttonStyle = [styles.buttonContainer];
     if (looksValid) {
       buttonStyle.push(styles.buttonContainerValid);

--- a/src/frontend/screens/central/view.ts
+++ b/src/frontend/screens/central/view.ts
@@ -201,7 +201,6 @@ class AppList extends PureComponent<AppListProps> {
   public render() {
     const apps = this.props.apps;
     const data = Object.keys(apps)
-      .filter(key => key.length >= 64)
       .map(key => apps[key]);
     const onPressApp = this.props.onPressApp;
 


### PR DESCRIPTION
`dat://` now supports domain lookups to resolve information, and it
would be nice if we could use hashbase.io domains (or any other domain)
to install applications, as it is easier to share.

I've tested it locally using a hashbase.io domain and it worked quite
nice.

This fixes #8
